### PR TITLE
feat: rename project to "Lard Lad Exchange"

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,11 @@
+### 🔍 What?
+<!-- One or two sentences describing what this PR does. -->
+
+### 💡 Why?
+<!-- The motivation — what are you learning or solving? -->
+
+### 🔀 What's changing?
+
+| File(s) | Change |
+|---|---|
+| `` |  |

--- a/README.md
+++ b/README.md
@@ -1,12 +1,15 @@
 <img src="https://flink.apache.org/img/logo/png/100/flink_squirrel_100_color.png" align="right" height="64px"/>
 
-# Hello Flink 👋
+# Lard Lad Exchange 🍩
 
-![License](https://img.shields.io/github/license/avcaliani/hello-flink?logo=apache&color=lightseagreen)
-![#](https://img.shields.io/badge/java-17-blue.svg)
-![#](https://img.shields.io/badge/apache--flink-2.0.x-ff4757.svg)
+![License](https://img.shields.io/github/license/avcaliani/deep-dive-flink?logo=apache&color=lightseagreen)
+![Java](https://img.shields.io/badge/Java-17-FF7800?logo=openjdk&logoColor=white)
+![Apache Flink](https://img.shields.io/badge/apache--flink-2.0.x-ff4757.svg)
 
 My repository with [Apache Flink](https://flink.apache.org) learnings.
+
+Lard Lad Donuts, Springfield's giant-donut landmark from *The Simpsons*.
+fitting, since this pipeline's whole job is moving (fictional) DonutCoin around.
 
 ### Quick Start
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 ![License](https://img.shields.io/github/license/avcaliani/deep-dive-flink?logo=apache&color=lightseagreen)
 ![Java](https://img.shields.io/badge/Java-17-FF7800?logo=openjdk&logoColor=white)
 ![Apache Flink](https://img.shields.io/badge/apache--flink-2.0.x-ff4757.svg)
+![Kafka](https://img.shields.io/badge/Kafka-231F20?logo=apachekafka&logoColor=white)
+![Docker](https://img.shields.io/badge/Docker-2496ED?logo=docker&logoColor=white)
 
 My repository with [Apache Flink](https://flink.apache.org) learnings.
 
@@ -27,7 +29,11 @@ curl -o "data/raw/users/users.csv" \
 docker compose up -d
 ```
 
-> 💡 [Reference](https://nightlies.apache.org/flink/flink-docs-release-2.0/docs/try-flink/local_installation/)
+> 💡 [Fink Local Installation](https://nightlies.apache.org/flink/flink-docs-release-2.0/docs/try-flink/local_installation/)
+
+> [!TIP]
+> **Kafka UI** ➜ http://localhost:8080  
+> **Flink Dashboard** ➜ http://localhost:8081
 
 03 - Start **kafka producer** ([ref](https://github.com/avcaliani/kafka-in-docker/tree/main/scripts)) 👇
 
@@ -56,6 +62,7 @@ docker compose exec kafka-dev /opt/scripts/donu-transactions.sh
 ---
 config:
   theme: 'base'
+  look: 'handDrawn'
   themeVariables:
     primaryColor: '#f6f8fa'
     primaryTextColor: '#24292f'

--- a/README.md
+++ b/README.md
@@ -8,10 +8,9 @@
 
 My repository with [Apache Flink](https://flink.apache.org) learnings.
 
-Lard Lad Donuts, Springfield's giant-donut landmark from *The Simpsons*.
-fitting, since this pipeline's whole job is moving (fictional) DonutCoin around.
+The app name is "Lard Lad Donuts", inspired on Springfield's giant-donut landmark from *The Simpsons*.
 
-### Quick Start
+## Quick Start
 
 01 - **Download** user mocked data.
 
@@ -51,7 +50,7 @@ docker compose exec kafka-dev /opt/scripts/donu-transactions.sh
       --kafka-brokers "kafka-dev:29092"
 ```
 
-#### Pipeline - Validate Transactions 
+## Pipeline - Validate Transactions
 
 ```mermaid
 ---

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -13,7 +13,7 @@ java {
 }
 
 application {
-    mainClass.set("br.avcaliani.hello_flink.App")
+    mainClass.set("br.avcaliani.lard_lad_exchange.App")
 }
 
 repositories {

--- a/run.sh
+++ b/run.sh
@@ -1,13 +1,13 @@
 #!/bin/bash -e
 
-JAR_FILE="hello-flink-1.0.0-uber.jar"
+JAR_FILE="lard-lad-exchange-1.0.0-uber.jar"
 CHECKPOINT_PATH="data/flink/checkpoint/"
 
 bold() {
   printf "\e[1m%s\e[m" "$1"
 }
 
-# Jar file will be at "build/libs/hello-flink-*-uber.jar"
+# Jar file will be at "build/libs/lard-lad-exchange-*-uber.jar"
 build_jar() {
   ./gradlew uberJar
 }
@@ -20,7 +20,7 @@ function create_checkpoint_path() {
 }
 
 printf "+------------------------------------------+\n"
-printf "| 🐿 %s                       |\n" "$(bold "Hello Flink App")"
+printf "| 🍩 %s                     |\n" "$(bold "Lard Lad Exchange")"
 printf "| Kafka UI        ➜ http://localhost:8080  |\n"
 printf "| Flink Dashboard ➜ http://localhost:8081  |\n"
 printf "+------------------------------------------+\n\n"

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "lard-lad-exchange"

--- a/src/main/java/br/avcaliani/lard_lad_exchange/App.java
+++ b/src/main/java/br/avcaliani/lard_lad_exchange/App.java
@@ -1,8 +1,8 @@
-package br.avcaliani.hello_flink;
+package br.avcaliani.lard_lad_exchange;
 
-import br.avcaliani.hello_flink.cli.ArgParser;
-import br.avcaliani.hello_flink.pipelines.Dummy;
-import br.avcaliani.hello_flink.pipelines.ValidateTransactions;
+import br.avcaliani.lard_lad_exchange.cli.ArgParser;
+import br.avcaliani.lard_lad_exchange.pipelines.Dummy;
+import br.avcaliani.lard_lad_exchange.pipelines.ValidateTransactions;
 
 public class App {
 

--- a/src/main/java/br/avcaliani/lard_lad_exchange/cli/ArgParser.java
+++ b/src/main/java/br/avcaliani/lard_lad_exchange/cli/ArgParser.java
@@ -1,4 +1,4 @@
-package br.avcaliani.hello_flink.cli;
+package br.avcaliani.lard_lad_exchange.cli;
 
 
 import org.apache.flink.configuration.Configuration;

--- a/src/main/java/br/avcaliani/lard_lad_exchange/cli/Args.java
+++ b/src/main/java/br/avcaliani/lard_lad_exchange/cli/Args.java
@@ -1,4 +1,4 @@
-package br.avcaliani.hello_flink.cli;
+package br.avcaliani.lard_lad_exchange.cli;
 
 import lombok.Data;
 import lombok.NoArgsConstructor;

--- a/src/main/java/br/avcaliani/lard_lad_exchange/infra/CSV.java
+++ b/src/main/java/br/avcaliani/lard_lad_exchange/infra/CSV.java
@@ -1,4 +1,4 @@
-package br.avcaliani.hello_flink.infra;
+package br.avcaliani.lard_lad_exchange.infra;
 
 import org.apache.flink.api.common.eventtime.WatermarkStrategy;
 import org.apache.flink.api.common.typeinfo.TypeInformation;

--- a/src/main/java/br/avcaliani/lard_lad_exchange/infra/Infra.java
+++ b/src/main/java/br/avcaliani/lard_lad_exchange/infra/Infra.java
@@ -1,4 +1,4 @@
-package br.avcaliani.hello_flink.infra;
+package br.avcaliani.lard_lad_exchange.infra;
 
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 

--- a/src/main/java/br/avcaliani/lard_lad_exchange/infra/Kafka.java
+++ b/src/main/java/br/avcaliani/lard_lad_exchange/infra/Kafka.java
@@ -1,8 +1,8 @@
-package br.avcaliani.hello_flink.infra;
+package br.avcaliani.lard_lad_exchange.infra;
 
-import br.avcaliani.hello_flink.infra.serializers.KafkaDeserializer;
-import br.avcaliani.hello_flink.infra.serializers.KafkaMessage;
-import br.avcaliani.hello_flink.infra.serializers.KafkaSerializer;
+import br.avcaliani.lard_lad_exchange.infra.serializers.KafkaDeserializer;
+import br.avcaliani.lard_lad_exchange.infra.serializers.KafkaMessage;
+import br.avcaliani.lard_lad_exchange.infra.serializers.KafkaSerializer;
 import org.apache.flink.api.common.eventtime.WatermarkStrategy;
 import org.apache.flink.api.connector.sink2.Sink;
 import org.apache.flink.connector.base.DeliveryGuarantee;
@@ -79,7 +79,7 @@ public class Kafka extends Infra {
         if (delivery == EXACTLY_ONCE) {
             sinkBuilder
                     .setProperty("transaction.timeout.ms", "900000")
-                    .setTransactionalIdPrefix("flink-app--"); // Mandatory when using Exactly Once
+                    .setTransactionalIdPrefix("lard-lad-exchange--"); // Mandatory when using Exactly Once
         }
         return sinkBuilder.build();
     }

--- a/src/main/java/br/avcaliani/lard_lad_exchange/infra/serializers/KafkaDeserializer.java
+++ b/src/main/java/br/avcaliani/lard_lad_exchange/infra/serializers/KafkaDeserializer.java
@@ -1,4 +1,4 @@
-package br.avcaliani.hello_flink.infra.serializers;
+package br.avcaliani.lard_lad_exchange.infra.serializers;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.json.JsonMapper;

--- a/src/main/java/br/avcaliani/lard_lad_exchange/infra/serializers/KafkaMessage.java
+++ b/src/main/java/br/avcaliani/lard_lad_exchange/infra/serializers/KafkaMessage.java
@@ -1,4 +1,4 @@
-package br.avcaliani.hello_flink.infra.serializers;
+package br.avcaliani.lard_lad_exchange.infra.serializers;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.Getter;

--- a/src/main/java/br/avcaliani/lard_lad_exchange/infra/serializers/KafkaSerializer.java
+++ b/src/main/java/br/avcaliani/lard_lad_exchange/infra/serializers/KafkaSerializer.java
@@ -1,4 +1,4 @@
-package br.avcaliani.hello_flink.infra.serializers;
+package br.avcaliani.lard_lad_exchange.infra.serializers;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/src/main/java/br/avcaliani/lard_lad_exchange/models/in/Transaction.java
+++ b/src/main/java/br/avcaliani/lard_lad_exchange/models/in/Transaction.java
@@ -1,6 +1,6 @@
-package br.avcaliani.hello_flink.models.in;
+package br.avcaliani.lard_lad_exchange.models.in;
 
-import br.avcaliani.hello_flink.infra.serializers.KafkaMessage;
+import br.avcaliani.lard_lad_exchange.infra.serializers.KafkaMessage;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
 import lombok.EqualsAndHashCode;

--- a/src/main/java/br/avcaliani/lard_lad_exchange/models/in/User.java
+++ b/src/main/java/br/avcaliani/lard_lad_exchange/models/in/User.java
@@ -1,4 +1,4 @@
-package br.avcaliani.hello_flink.models.in;
+package br.avcaliani.lard_lad_exchange.models.in;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;

--- a/src/main/java/br/avcaliani/lard_lad_exchange/models/out/DTOTransaction.java
+++ b/src/main/java/br/avcaliani/lard_lad_exchange/models/out/DTOTransaction.java
@@ -1,8 +1,8 @@
-package br.avcaliani.hello_flink.models.out;
+package br.avcaliani.lard_lad_exchange.models.out;
 
-import br.avcaliani.hello_flink.infra.serializers.KafkaMessage;
-import br.avcaliani.hello_flink.models.in.Transaction;
-import br.avcaliani.hello_flink.models.in.User;
+import br.avcaliani.lard_lad_exchange.infra.serializers.KafkaMessage;
+import br.avcaliani.lard_lad_exchange.models.in.Transaction;
+import br.avcaliani.lard_lad_exchange.models.in.User;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;

--- a/src/main/java/br/avcaliani/lard_lad_exchange/models/out/DTOUser.java
+++ b/src/main/java/br/avcaliani/lard_lad_exchange/models/out/DTOUser.java
@@ -1,6 +1,6 @@
-package br.avcaliani.hello_flink.models.out;
+package br.avcaliani.lard_lad_exchange.models.out;
 
-import br.avcaliani.hello_flink.models.in.User;
+import br.avcaliani.lard_lad_exchange.models.in.User;
 import lombok.Data;
 
 @Data

--- a/src/main/java/br/avcaliani/lard_lad_exchange/pipelines/Dummy.java
+++ b/src/main/java/br/avcaliani/lard_lad_exchange/pipelines/Dummy.java
@@ -1,8 +1,8 @@
-package br.avcaliani.hello_flink.pipelines;
+package br.avcaliani.lard_lad_exchange.pipelines;
 
-import br.avcaliani.hello_flink.cli.Args;
-import br.avcaliani.hello_flink.models.in.User;
-import br.avcaliani.hello_flink.models.out.DTOUser;
+import br.avcaliani.lard_lad_exchange.cli.Args;
+import br.avcaliani.lard_lad_exchange.models.in.User;
+import br.avcaliani.lard_lad_exchange.models.out.DTOUser;
 import org.apache.flink.api.common.eventtime.WatermarkStrategy;
 import org.apache.flink.api.common.functions.MapFunction;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
@@ -35,7 +35,7 @@ public class Dummy extends Pipeline {
             return dto;
         })
         .print();
-        env.execute("hello-flink--dummy");
+        env.execute("lard-lad-exchange--dummy");
         return this;
     }
 

--- a/src/main/java/br/avcaliani/lard_lad_exchange/pipelines/Pipeline.java
+++ b/src/main/java/br/avcaliani/lard_lad_exchange/pipelines/Pipeline.java
@@ -1,6 +1,6 @@
-package br.avcaliani.hello_flink.pipelines;
+package br.avcaliani.lard_lad_exchange.pipelines;
 
-import br.avcaliani.hello_flink.cli.Args;
+import br.avcaliani.lard_lad_exchange.cli.Args;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/src/main/java/br/avcaliani/lard_lad_exchange/pipelines/ValidateTransactions.java
+++ b/src/main/java/br/avcaliani/lard_lad_exchange/pipelines/ValidateTransactions.java
@@ -1,11 +1,11 @@
-package br.avcaliani.hello_flink.pipelines;
+package br.avcaliani.lard_lad_exchange.pipelines;
 
-import br.avcaliani.hello_flink.cli.Args;
-import br.avcaliani.hello_flink.infra.CSV;
-import br.avcaliani.hello_flink.infra.Kafka;
-import br.avcaliani.hello_flink.models.in.Transaction;
-import br.avcaliani.hello_flink.models.in.User;
-import br.avcaliani.hello_flink.models.out.DTOTransaction;
+import br.avcaliani.lard_lad_exchange.cli.Args;
+import br.avcaliani.lard_lad_exchange.infra.CSV;
+import br.avcaliani.lard_lad_exchange.infra.Kafka;
+import br.avcaliani.lard_lad_exchange.models.in.Transaction;
+import br.avcaliani.lard_lad_exchange.models.in.User;
+import br.avcaliani.lard_lad_exchange.models.out.DTOTransaction;
 import org.apache.flink.api.common.state.MapStateDescriptor;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.functions.co.BroadcastProcessFunction;
@@ -35,7 +35,7 @@ public class ValidateTransactions extends Pipeline {
 
         var transactions = kafka.read(
                 "DONU_TRANSACTIONS_V1", /* Topic */
-                "hello-flink--validate-txn-pipeline", /* Group ID */
+                "lard-lad-exchange--validate-txn-pipeline", /* Group ID */
                 Transaction.class
         );
 
@@ -53,7 +53,7 @@ public class ValidateTransactions extends Pipeline {
         );
         richTxn.filter(DTOTransaction::isInvalid).sinkTo(deadLetterSink);
 
-        env.execute("hello-flink--validate-transactions");
+        env.execute("lard-lad-exchange--validate-transactions");
         return this;
     }
 


### PR DESCRIPTION
### 🔍 What?
Renames the project from the generic "Hello Flink" to **Lard Lad Exchange**, including the Java package, Flink job names, Kafka identifiers, and the run.sh banner.

### 💡 Why?
The pipeline validates fictional DONU (DonutCoin) transactions, so it deserves a name that fits instead of a placeholder — Lard Lad Donuts is Springfield's giant-donut landmark from *The Simpsons*.

### 🔀 What's changing?

| File(s) | Change |
|---|---|
| `README.md` | Title, intro sentence, and badges (fixed stale repo link, added logos) |
| `src/main/java/br/avcaliani/{hello_flink → lard_lad_exchange}/**` | Package rename across all 17 source files (package decl + imports) |
| `build.gradle.kts` | `mainClass` updated to new package |
| `settings.gradle.kts` | New file — sets `rootProject.name`, previously unset |
| `run.sh` | Banner text, `JAR_FILE` name, comment |
| `pipelines/Dummy.java`, `pipelines/ValidateTransactions.java` | Flink job names (`env.execute(...)`), Kafka consumer group id |
| `infra/Kafka.java` | Kafka transactional id prefix |
| `.github/PULL_REQUEST_TEMPLATE.md` | New file, matches the template used in `deep-dive-pyspark` |

No functional changes — only naming.

🤖 Generated with [Claude Code](https://claude.com/claude-code)